### PR TITLE
Enable RDS storage autoscaling for PostgreSQL instances

### DIFF
--- a/v2-docker/terraform/modules/rds/main.tf
+++ b/v2-docker/terraform/modules/rds/main.tf
@@ -92,8 +92,9 @@ resource "aws_db_instance" "main" {
   engine_version = var.engine_version
   instance_class = var.instance_class
 
-  allocated_storage = var.allocated_storage
-  storage_type      = "gp3"
+  allocated_storage     = var.allocated_storage
+  max_allocated_storage = var.max_allocated_storage # 스토리지 오토스케일링: 사용량 90% 도달 시 현재 크기의 20% 자동 확장 (최소 5GB)
+  storage_type          = "gp3"
 
   db_name  = var.db_name
   username = var.username

--- a/v2-docker/terraform/modules/rds/variables.tf
+++ b/v2-docker/terraform/modules/rds/variables.tf
@@ -15,6 +15,12 @@ variable "allocated_storage" {
   default     = 20
 }
 
+variable "max_allocated_storage" {
+  description = "스토리지 오토스케일링 최대 크기 (GB). allocated_storage보다 크게 설정하면 오토스케일링 활성화. 사용량 90% 도달 시 자동 확장 트리거"
+  type        = number
+  default     = 100
+}
+
 variable "engine_version" {
   description = "PostgreSQL 엔진 버전"
   type        = string


### PR DESCRIPTION
요약
max_allocated_storage 변수를 새롭게 도입하고 AWS RDS 인스턴스 리소스에 이를 설정함으로써, PostgreSQL 데이터베이스 인스턴스에 대한 RDS 스토리지 자동 확장 기능을 추가했습니다.

주요 변경 사항
RDS 모듈에 max_allocated_storage 변수 추가 (기본값: 100 GB)

해당 값이 allocated_storage보다 클 경우 자동 확장 기능이 활성화된다는 설명을 문서에 포함했습니다.

스토리지 사용량이 90%에 도달하면 자동으로 확장이 트리거됩니다.

aws_db_instance 리소스 업데이트

새로운 max_allocated_storage 파라미터를 사용하도록 리소스를 수정했습니다.

90% 임계치에 도달하면 AWS는 현재 크기의 20%(최소 5 GB)만큼 스토리지를 자동으로 확장합니다.

구현 상세 내용
선택적 도입(Opt-in): 사용자가 max_allocated_storage 값을 allocated_storage와 같거나 작게 설정하면 자동 확장 기능을 비활성화할 수 있습니다.

기본 설정: 스토리지가 20 GB에서 최대 100 GB까지 자동으로 확장되도록 구성되었습니다.

효과: 최대 한도 설정을 통해 비용을 제어하는 동시에, 스토리지 용량 부족으로 인한 데이터베이스 서비스 중단을 방지합니다.